### PR TITLE
Make the scan-interval a parameter for the Helm (Dev) deployment.

### DIFF
--- a/templates/configmaps/cosmic-vault-files/_cosmic-metrics-collector.json.tpl
+++ b/templates/configmaps/cosmic-vault-files/_cosmic-metrics-collector.json.tpl
@@ -16,7 +16,7 @@
   },
   "cosmic": {
     "metrics-collector": {
-      "scan-interval": "0 */15 * * * *",
+      "scan-interval": {{ .Values.cosmic_vault.cosmic_scan_interval | quote }},
       "broker-exchange": "cosmic-metrics-exchange",
       "broker-exchange-key": "cosmic-metrics-key"
     }

--- a/templates/configmaps/cosmic-vault-files/_cosmic-usage-api.json.tpl
+++ b/templates/configmaps/cosmic-vault-files/_cosmic-usage-api.json.tpl
@@ -22,7 +22,7 @@
   },
   "cosmic": {
     "usage-api": {
-      "scan-interval": "0 */15 * * * *"
+      "scan-interval": {{ .Values.cosmic_vault.cosmic_scan_interval | quote }}
     }
   }
 }

--- a/values.yaml
+++ b/values.yaml
@@ -60,6 +60,7 @@ elasticsearch:
 
 cosmic_vault:
   image_tag: latest
+  cosmic_scan_interval: "0 */15 * * * *"
 
 cosmic_usage_api:
   image_tag: latest


### PR DESCRIPTION
As current Helm chart only controls the configuration for the metrics-collector
and the usage-api in Dev mode, the parameter has been placed under cosmic_vault,
as that is also only used in Dev mode.